### PR TITLE
Add an onlinePath Argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,23 @@ minify: {
 },
 ```
 
+### onlinePath
+
+```js
+string
+```
+
+A path to append to file references injected. This is useful for putting files on a CDN after building.
+
+#### Example
+```js
+onlinePath: '//www.example.com/foo',
+```
+Which will generate:
+```html
+<script src="//www.example.com/foo/main.js"></script>
+```
+
 ## License
 
 [MIT](LICENSE) © [Petr Tsymbarovich](mailto:petr@tsymbarovich.ru)

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ interface IPluginOptions {
   preload?: string[] | Set<string>
   modules?: boolean
   minify?: false | MinifyOptions
+  onlinePath?: string
 }
 
 const enum Cache {
@@ -175,6 +176,7 @@ export default ({
   preload,
   modules,
   minify: minifyOptions,
+  onlinePath: onlinePath,
   ...options
 }: IPluginOptions): Plugin => ({
   name: 'html2',
@@ -329,12 +331,12 @@ consider to use the esm format or switch off the option`)
         const {name, ext} = path.parse(fileName)
         const injectType = ext.slice(1)
         if (name in entries) {
-          injectCSSandJS('/' + fileName, injectType, inject)
+          injectCSSandJS((onlinePath === undefined ? '' : onlinePath) + '/' + fileName, injectType, inject)
         } else if (name in dynamicEntries && (preload as Set<string>).has(dynamicEntries[name])) {
           const linkType = extensionToType(injectType)
           if (linkType) {
             addNewLine(head)
-            head.appendChild(new HTMLElement('link', {}, `rel="preload" href="/${fileName}" as="${linkType}"`))
+            head.appendChild(new HTMLElement('link', {}, `rel="preload" href="${(onlinePath === undefined ? '' : onlinePath)}/${fileName}" as="${linkType}"`))
           }
         }
       })


### PR DESCRIPTION
Thank you for making this project, it has been incredibly useful.

There is a feature I believe is missing, though: `rollup-plugin-bundle-html` allows users to provide an `onlinePath` string to append to the start of resources, and as far as I could tell, there is no way to do this in `rollup-plugin-html2`. This would be a useful feature for publishing files to CDNs where resources won't be on the same path as a published html file.