### PR TITLE
fix: duplicate favicons and absolute favicons file name in emit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -323,9 +323,10 @@ or change the \`type\``)
     if (favicon) {
       const nodes    = head.querySelectorAll('link')
       const rel      = 'shortcut icon'
-      const oldLink  = nodes.find(n => n.attributes.rel === rel)
-      const fileName = prefix + path.basename(favicon)
-      const newLink  = new HTMLElement('link', {}, `rel="${rel}" href="${fileName}"`, head)
+      const oldLink = nodes.find(n => n.attributes.rel === rel)
+      const fileName = path.basename(favicon)
+      const filePath = prefix + fileName
+      const newLink  = new HTMLElement('link', {}, `rel="${rel}" href="${filePath}"`, head)
       if (oldLink) {
         head.exchangeChild(oldLink, newLink)
       } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,25 +287,6 @@ or change the \`type\``)
 
     const prefix = normalizePrefix(onlinePath)
 
-    if (favicon) {
-      const nodes    = head.querySelectorAll('link')
-      const rel      = 'shortcut icon'
-      const oldLink  = nodes.find(n => n.attributes.rel === rel)
-      const fileName = prefix + path.basename(favicon)
-      const newLink  = new HTMLElement('link', {}, `rel="${rel}" href="${fileName}"`, head)
-      if (oldLink) {
-        head.exchangeChild(oldLink, newLink)
-      } else {
-        addNewLine(head)
-        head.appendChild(newLink)
-      }
-      this.emitFile({
-        fileName,
-        source: fs.readFileSync(favicon),
-        type:   'asset',
-      })
-    }
-
     const appendNode = appendNodeFactory(this, head, body)
 
     const processExternal = (e: External) => {
@@ -337,6 +318,25 @@ or change the \`type\``)
           }
         }
       }
+    }
+
+    if (favicon) {
+      const nodes    = head.querySelectorAll('link')
+      const rel      = 'shortcut icon'
+      const oldLink  = nodes.find(n => n.attributes.rel === rel)
+      const fileName = prefix + path.basename(favicon)
+      const newLink  = new HTMLElement('link', {}, `rel="${rel}" href="${fileName}"`, head)
+      if (oldLink) {
+        head.exchangeChild(oldLink, newLink)
+      } else {
+        addNewLine(head)
+        head.appendChild(newLink)
+      }
+      this.emitFile({
+        fileName,
+        source: fs.readFileSync(favicon),
+        type:   'asset',
+      })
     }
 
     // Inject externals after


### PR DESCRIPTION
1. Because the `favicon` option was being handled and emitting the favicon before the `inject` flag, it was inserting the favicon `link` twice.
2. When using the `favicon` with the `onlinePath` option, an error would be thrown if the `onlinePath` started with a `/`. Instead, the build copies the file as is and sets the `link` to access it with the prepended `onlinePath`.

I'm not sure if this project is still being maintained but if anyone else needs these changes (as I do) you can install with straight from my repo: `npm install NoahCardoza/rollup-plugin-html2#build`

Hope this helps someone!