### PR TITLE
fix: correct CommonJS export path

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "require": "./dist/cjs/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary
- correct the CommonJS export target from `dist/cjs/index.cjs` to the built `dist/cjs/index.js`

## Why
The package currently publishes `dist/cjs/index.js`, but the `exports.require` entry points to `dist/cjs/index.cjs`. As a result, `require('rollup-plugin-html2')` fails after installing the published package.

## Verification
- `npm run build:cjs`
- `npm run build:esm`
- `npm run build:types`
- packed the package and verified both `require('rollup-plugin-html2')` and ESM import from a clean consumer install