### PR TITLE
Fix missing CommonJS export artifact

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "prebuild": "pnpm run lint",
     "build": "npm run build:cjs && npm run build:esm && npm run build:types",
-    "build:cjs": "tsc -m commonjs --outDir dist/cjs",
+    "build:cjs": "tsc -m commonjs --outDir dist/cjs && node scripts/rename-cjs-output.mjs",
     "build:esm": "tsc -m es6",
     "build:types": "tsc -d --emitDeclarationOnly",
     "docs": "npx typedoc src/types.ts && npx gh-pages -d docs",

--- a/scripts/rename-cjs-output.mjs
+++ b/scripts/rename-cjs-output.mjs
@@ -1,0 +1,12 @@
+import { existsSync, renameSync } from "node:fs";
+import { join } from "node:path";
+
+const cjsDir = join(process.cwd(), "dist", "cjs");
+const jsPath = join(cjsDir, "index.js");
+const cjsPath = join(cjsDir, "index.cjs");
+
+if (!existsSync(jsPath)) {
+  throw new Error(`Expected CommonJS build output at ${jsPath}`);
+}
+
+renameSync(jsPath, cjsPath);


### PR DESCRIPTION
## Summary
- emit the CommonJS build artifact as `dist/cjs/index.cjs` so the published `require` export points at a real file
- keep the existing ESM and types outputs unchanged
- add a tiny build helper script that renames the generated CommonJS output after TypeScript compilation

## Root cause
The package declares `"require": "./dist/cjs/index.cjs"`, but the CommonJS TypeScript build emits `dist/cjs/index.js` by default, so the published tarball misses the file required by the package export contract.

## Validation
- `npx tsc -m commonjs --outDir dist/cjs`
- `node scripts/rename-cjs-output.mjs`
- `npx tsc -m es6`
- `npx tsc -d --emitDeclarationOnly`
- `npm pack --ignore-scripts`
- clean-install smoke test: `require('rollup-plugin-html2')` succeeds from the packed tarball
- `git diff --check`

## Notes
- `npm run build` currently depends on `pnpm run lint` in `prebuild`, and `pnpm` was not installed in this environment, so I validated the underlying build steps directly instead.