### PR TITLE
Allow injecting scripts into head or body

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,13 +122,15 @@ export interface RollupHTML2PluginOptions {
   /**
    * Defines whether to inject bundled files or not.
    * If set to `false` then bundled files are not injected.
+   * If set to `"head"` or `"body"` then script tags are injected to
+   * the selected element.
    *
    * @default
    * ```js
    * true
    * ```
    */
-  inject?: boolean;
+  inject?: boolean | "head" | "body";
 
   /**
    * Sets the title of the output HTML document.
@@ -314,8 +316,10 @@ const html2: RollupHTML2Plugin = ({
       this.error("The provided favicon file does't exist");
     }
 
-    if (typeof inject === "string") {
-      this.warn("Invalid `inject` must be `true`, `false` or `undefined`");
+    if (typeof inject === "string" && inject !== "head" && inject !== "body") {
+      this.warn(
+        'Invalid `inject` must be `true | false | "head" | "body" | undefined`',
+      );
       inject = true;
     }
 
@@ -446,7 +450,11 @@ or change the \`type\``);
 
     const prefix = normalizePrefix(onlinePath);
 
-    const appendNode = appendNodeFactory(this, head, body);
+    const appendNode = appendNodeFactory(
+      this,
+      head,
+      inject === "head" ? head : body,
+    );
 
     const processExternal = (e: External) => {
       if (!e.tag) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -34,7 +34,7 @@ type NodeAppender = (
 export function appendNodeFactory(
   context: PluginContext,
   head: HTMLElement,
-  body: HTMLElement,
+  scriptParent: HTMLElement,
 ): NodeAppender {
   return (options = {}, filePath) => {
     // Check if `as` is set
@@ -87,7 +87,7 @@ set to "preload" but no `as` option defined',
       prev += " ";
       return prev;
     }, "");
-    const parent = tag === "script" ? body : head;
+    const parent = tag === "script" ? scriptParent : head;
     addNewLine(parent);
     const entry = new HTMLElement(tag, {}, attrsstr, parent, [-1, -1]);
     parent.appendChild(entry);

--- a/test/html2.test.ts
+++ b/test/html2.test.ts
@@ -234,6 +234,60 @@ test("can disable generated file injection", async () => {
   assert.doesNotMatch(html, /<link/);
 });
 
+test("can inject script tags into the head", async () => {
+  const output = await rollupWithHtml2({
+    entries: {
+      main: { tag: "script" },
+    },
+    externals: {
+      before: [{ tag: "script", src: "https://cdn.example/library.js" }],
+    },
+    fileName: "index.html",
+    inject: "head",
+    template: "<html><head></head><body></body></html>",
+  });
+
+  const mainChunk = getChunk(output, "main");
+  const html = String(getAsset(output, "index.html").source);
+  const document = parse(html);
+
+  assert.ok(
+    document.querySelector('head script[src="https://cdn.example/library.js"]'),
+  );
+  assert.ok(
+    document.querySelector(`head script[src="/${mainChunk.fileName}"]`),
+  );
+  assert.equal(document.querySelectorAll("body script").length, 0);
+});
+
+test("injects bundled CSS assets as stylesheet links", async () => {
+  const output = await generate({
+    html2Options: {
+      fileName: "index.html",
+      template: "<html><head></head><body></body></html>",
+    },
+    plugins: [
+      {
+        name: "test-css-asset",
+        generateBundle() {
+          this.emitFile({
+            fileName: "bundle.css",
+            source: "body { color: black; }",
+            type: "asset",
+          });
+        },
+      },
+    ],
+  });
+
+  const html = String(getAsset(output, "index.html").source);
+  const document = parse(html);
+
+  assert.ok(
+    document.querySelector('head link[rel="stylesheet"][href="/bundle.css"]'),
+  );
+});
+
 test("replaces existing meta and favicon links and emits the favicon asset", async () => {
   const output = await rollupWithHtml2({
     favicon: path.join(fixturesDir, "favicon.ico"),
@@ -322,7 +376,7 @@ test("warns about unknown options, string inject values, and excluded configured
 
   assert.deepEqual(warnings, [
     "[plugin html2] Ignoring unknown option `unknown`",
-    "[plugin html2] Invalid `inject` must be `true`, `false` or `undefined`",
+    '[plugin html2] Invalid `inject` must be `true | false | "head" | "body" | undefined`',
     '[plugin html2] Excluding a configured entry "main"',
   ]);
 });


### PR DESCRIPTION
Allow the `inject` option to accept `"head"` or `"body"` strings to specify where script tags should be placed in the HTML document. Defaults to the standard behavior of injecting scripts into the body.

Fix #14 