### PR TITLE
Normalize package repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://mentaljam.github.io/rollup-plugin-html2",
   "repository": {
     "type": "git",
-    "url": "git+ssh://github.com/mentaljam/rollup-plugin-html2"
+    "url": "git+https://github.com/mentaljam/rollup-plugin-html2.git"
   },
   "bugs": {
     "url": "https://github.com/mentaljam/rollup-plugin-html2/issues"


### PR DESCRIPTION
## Summary

- Replace the package repository URL with the public GitHub HTTPS git URL.
- Leave runtime code, package version, homepage, bugs metadata, and package contents unchanged.

## Validation

```sh
node -e 'const p=require("./package.json"); if (p.repository.url !== "git+https://github.com/mentaljam/rollup-plugin-html2.git") throw new Error(p.repository.url); if (p.homepage !== "https://mentaljam.github.io/rollup-plugin-html2") throw new Error("homepage changed"); if (p.bugs.url !== "https://github.com/mentaljam/rollup-plugin-html2/issues") throw new Error("bugs changed"); console.log("metadata ok")'
npm pack --dry-run --ignore-scripts --json .
corepack pnpm install --frozen-lockfile --ignore-scripts
corepack pnpm run lint
corepack pnpm run build
corepack pnpm test
git diff --check
```
