### PR TITLE
chore: use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://mentaljam.github.io/rollup-plugin-html2",
   "repository": {
     "type": "git",
-    "url": "git+ssh://github.com/mentaljam/rollup-plugin-html2"
+    "url": "git+https://github.com/mentaljam/rollup-plugin-html2.git"
   },
   "bugs": {
     "url": "https://github.com/mentaljam/rollup-plugin-html2/issues"


### PR DESCRIPTION
## Summary
- replace the SSH-style package repository URL with a public HTTPS GitHub URL
- keep the existing repository object shape and all runtime/package settings unchanged

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run build`
- `pnpm test`
- `node -e 'const p=require("./package.json"); if (p.repository.url !== "git+https://github.com/mentaljam/rollup-plugin-html2.git") throw new Error(p.repository.url); console.log("metadata ok")'`
